### PR TITLE
PAE-581: Add cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,8 +40,11 @@ updates:
 
     # Schedule run nightly
     schedule:
-      interval: "cron"
-      cronjob: "0 0 * * *"
+      interval: 'cron'
+      cronjob: '0 0 * * *'
+
+    cooldown:
+      default-days: 3
 
     versioning-strategy: increase
 
@@ -55,5 +58,5 @@ updates:
 
     # Schedule run nightly
     schedule:
-      interval: "cron"
-      cronjob: "0 0 * * *"
+      interval: 'cron'
+      cronjob: '0 0 * * *'


### PR DESCRIPTION
This pull request updates the Dependabot configuration in `.github/dependabot.yml` to adjust scheduling settings and introduce a cooldown period for updates.

Configuration changes:

* Changed the `interval` and `cronjob` values in the `schedule` section to use single quotes for consistency. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L43-R47) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L58-R62)
* Added a new `cooldown` section with `default-days: 3` to set a cooldown period of three days between updates.