### PR TITLE
PAE-1009: Resolves Snyk alerts

### DIFF
--- a/app/views/admin-ui/service-maintainer/concept/select-an-organisation/index.js
+++ b/app/views/admin-ui/service-maintainer/concept/select-an-organisation/index.js
@@ -18,7 +18,8 @@ function loadOrgData() {
 }
 
 function GET(req, res, next) {
-	const searchTerm = ((req.query && req.query['org-search']) || '').trim().toLowerCase()
+	const rawSearch = req.query?.['org-search']
+	const searchTerm = (typeof rawSearch === 'string' ? rawSearch : '').trim().toLowerCase()
 
 	const filterBySearchTerm = searchTerm.length
 		? org => [org.name, org.orgId]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "format": "prettier --write \"**/*.{cjs,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{cjs,js,json,md}\""
   },
+  "overrides": {
+    "qs": "6.14.1",
+    "lodash": "4.17.23"
+  },
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "2.0.1",
     "govuk-frontend": "5.13.0",


### PR DESCRIPTION
## Summary
Resolves Snyk security alerts for vulnerable transitive dependencies (qs, lodash) and fixes a code quality issue with improper type validation on query parameters.

## What Changed
- Added npm overrides to force `qs@6.14.1` and `lodash@4.17.23`, patching CVE-2025-15284 (high) and CVE-2025-13465 (medium)
- Fixed type validation in organisation search to handle array query parameters safely

## Why
Snyk flagged three security issues: two vulnerable transitive dependencies from govuk-prototype-kit, and a code path where query params could crash the app if passed as arrays. The overrides bypass the kit's pinned versions until upstream updates, and the type check prevents potential DoS via malformed requests.