### PR TITLE
PAE-1009: Revert security patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,6 @@
     "format": "prettier --write \"**/*.{cjs,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{cjs,js,json,md}\""
   },
-  "overrides": {
-    "qs": "6.14.1",
-    "lodash": "4.17.23"
-  },
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "2.0.1",
     "govuk-frontend": "5.14.0",


### PR DESCRIPTION
## Summary
Reverts the npm overrides for qs and lodash added in #13, as they have no effect on the resolved dependency tree.

## What Changed
- Removed `overrides` section from `package.json` (qs@6.14.1, lodash@4.17.23)

## Why
npm overrides cannot override exact version pins in nested dependency trees. Express 4.21.2 pins qs to exactly 6.13.0, and govuk-prototype-kit pins lodash to 4.17.21 — the overrides were being recognised by npm but not applied. The qs and lodash vulnerabilities are transitive dependencies of govuk-prototype-kit@13.18.1 (latest) and the fix must come from upstream. These have been ignored in Snyk accordingly.